### PR TITLE
context review

### DIFF
--- a/articles/app-service/azure-sdk-dotnet-release-notes-2-9.md
+++ b/articles/app-service/azure-sdk-dotnet-release-notes-2-9.md
@@ -84,7 +84,7 @@ Azure SDK 2.9의 새로운 변경 내용은 이번 릴리스에 도입되지 않
 * **서버 탐색기** 를 통해 모든 항목을 보고 일부 U-SQL 메타데이터 엔터티를 만들 수 있습니다. 자세한 내용은 [이 블로그](https://azure.microsoft.com/documentation/services/data-lake-analytics/) 를 참조하세요.
 
 ## <a name="hdinsight-tools"></a>HDInsight 도구
-**HDInsight 도구** 에서 Tez 그래프 표시 및 기타 언어 수정을 포함하여 HDInsight 버전 3.3을 지원합니다.
+Visual Studio **HDInsight 도구** 는 Tez 그래프 표시 및 기타 언어 수정을 포함하여 HDInsight 버전 3.3을 지원합니다.
 
 ## <a name="azure-resource-manager"></a>Azure 리소스 관리자
 이 릴리스는 Resource Manager 템플릿에 대한 [KeyVault](../azure-resource-manager/resource-manager-keyvault-parameter.md) 지원을 추가했습니다.

--- a/articles/app-service/azure-sdk-dotnet-release-notes-2-9.md
+++ b/articles/app-service/azure-sdk-dotnet-release-notes-2-9.md
@@ -84,7 +84,7 @@ Azure SDK 2.9의 새로운 변경 내용은 이번 릴리스에 도입되지 않
 * **서버 탐색기** 를 통해 모든 항목을 보고 일부 U-SQL 메타데이터 엔터티를 만들 수 있습니다. 자세한 내용은 [이 블로그](https://azure.microsoft.com/documentation/services/data-lake-analytics/) 를 참조하세요.
 
 ## <a name="hdinsight-tools"></a>HDInsight 도구
-Visual Studio **HDInsight 도구** 는 Tez 그래프 표시 및 기타 언어 수정을 포함하여 HDInsight 버전 3.3을 지원합니다.
+Visual Studio용 **HDInsight 도구**는 Tez 그래프 표시 및 기타 언어 수정을 포함하여 HDInsight 버전 3.3을 지원합니다.
 
 ## <a name="azure-resource-manager"></a>Azure 리소스 관리자
 이 릴리스는 Resource Manager 템플릿에 대한 [KeyVault](../azure-resource-manager/resource-manager-keyvault-parameter.md) 지원을 추가했습니다.


### PR DESCRIPTION
“에서” is wrong in this context, changed “에서” to “는” to be grammatically more correct. Also added “Visual Studio” as same as the original English context.