### PR TITLE
Fix source code error

### DIFF
--- a/articles/iot-edge/tutorial-python-module.md
+++ b/articles/iot-edge/tutorial-python-module.md
@@ -150,7 +150,7 @@ VS 코드를 사용하여 빌드할 수 있는 Python 솔루션 템플릿을 만
                     if "machine" in data and "temperature" in data["machine"] and data["machine"]["temperature"] > TEMPERATURE_THRESHOLD:
                         custom_properties["MessageType"] = "Alert"
                         print ( "Machine temperature %s exceeds threshold %s" % (data["machine"]["temperature"], TEMPERATURE_THRESHOLD))
-                        await module_client.send_message_to_output(input_message, "outputs")
+                        await module_client.send_message_to_output(input_message, "output1")
                 except Exception as ex:
                     print ( "Unexpected error in input1_listener: %s" % ex )
 

--- a/articles/iot-edge/tutorial-python-module.md
+++ b/articles/iot-edge/tutorial-python-module.md
@@ -131,7 +131,7 @@ VS 코드를 사용하여 빌드할 수 있는 Python 솔루션 템플릿을 만
 
     ```python
         # Define behavior for receiving an input message on input1
-        # Because this is a filter module, we forward this message to the "output" queue.
+        # Because this is a filter module, we forward this message to the "outputs" queue.
         async def input1_listener(module_client):
             global RECEIVED_MESSAGES
             global TEMPERATURE_THRESHOLD
@@ -150,7 +150,7 @@ VS 코드를 사용하여 빌드할 수 있는 Python 솔루션 템플릿을 만
                     if "machine" in data and "temperature" in data["machine"] and data["machine"]["temperature"] > TEMPERATURE_THRESHOLD:
                         custom_properties["MessageType"] = "Alert"
                         print ( "Machine temperature %s exceeds threshold %s" % (data["machine"]["temperature"], TEMPERATURE_THRESHOLD))
-                        await module_client.send_message_to_output(input_message, "output")
+                        await module_client.send_message_to_output(input_message, "outputs")
                 except Exception as ex:
                     print ( "Unexpected error in input1_listener: %s" % ex )
 

--- a/articles/iot-edge/tutorial-python-module.md
+++ b/articles/iot-edge/tutorial-python-module.md
@@ -131,7 +131,7 @@ VS 코드를 사용하여 빌드할 수 있는 Python 솔루션 템플릿을 만
 
     ```python
         # Define behavior for receiving an input message on input1
-        # Because this is a filter module, we forward this message to the "output1" queue.
+        # Because this is a filter module, we forward this message to the "output" queue.
         async def input1_listener(module_client):
             global RECEIVED_MESSAGES
             global TEMPERATURE_THRESHOLD
@@ -150,7 +150,7 @@ VS 코드를 사용하여 빌드할 수 있는 Python 솔루션 템플릿을 만
                     if "machine" in data and "temperature" in data["machine"] and data["machine"]["temperature"] > TEMPERATURE_THRESHOLD:
                         custom_properties["MessageType"] = "Alert"
                         print ( "Machine temperature %s exceeds threshold %s" % (data["machine"]["temperature"], TEMPERATURE_THRESHOLD))
-                        await module_client.send_message_to_output(input_message, "output1")
+                        await module_client.send_message_to_output(input_message, "output")
                 except Exception as ex:
                     print ( "Unexpected error in input1_listener: %s" % ex )
 


### PR DESCRIPTION
문서에서 Copy & Paste 해야 하는 소스코드에는 output1 queue로
메시지를 라우팅하도록 작성되어 있지만
실제 vscode-iotedge-extension 에서 생성되는 기본 예제의
deployment_template.json 파일에는 'outputs'으로 라우팅 하도록 되어 있습니다.

이 commit과 같이 소스코드를 수정하거나 deployment_template.json 의
라우팅을 outputs 에서 output1으로  변경하여야 예제가 동작합니다.

제안하는 데 유용한 정보:
1. [빠른 시작 지역화 스타일 가이드](https://docs.microsoft.com/globalization/localization/styleguides)로 이동하여 Microsoft 스타일 가이드에서 **상위 10개의 가장 중요한 규칙**을 확인합니다.
2. [Microsoft 언어 포털](https://www.microsoft.com/language)로 이동하여 Microsoft 제품에서 **표준화된 용어 번역**을 확인합니다.
