### PR TITLE
Update deploy-nextjs.md

### DIFF
--- a/articles/static-web-apps/deploy-nextjs.md
+++ b/articles/static-web-apps/deploy-nextjs.md
@@ -69,7 +69,7 @@ Next.js CLI를 사용하여 앱을 만드는 대신 기존 Next.js 앱이 포함
 
 `npm run build`를 사용하여 Next.js를 빌드하면 앱은 정적 사이트가 아닌 기존 웹앱으로 빌드됩니다. 정적 사이트를 생성하려면 다음 애플리케이션 구성을 사용합니다.
 
-1. 정적 경로를 구성하려면 프로젝트 루트에 _next.config.js_라는 파일을 만들고 다음 코드를 추가합니다.
+1. 정적 경로를 구성하려면 프로젝트 루트에 _next.config.js_ 라는 파일을 만들고 다음 코드를 추가합니다.
 
     ```javascript
     module.exports = {
@@ -84,7 +84,7 @@ Next.js CLI를 사용하여 앱을 만드는 대신 기존 Next.js 앱이 포함
     
       이 구성은 `/`를 `/` 경로에 대해 제공되는 Next.js 페이지와 _pages/index.js_ 페이지 파일에 매핑합니다.
 
-1. `next export` 명령을 사용하여 빌드 후 정적 사이트도 생성하도록 _package.json_의 빌드 스크립트를 업데이트합니다. `export` 명령은 정적 사이트를 생성합니다.
+1. `next export` 명령을 사용하여 빌드 후 정적 사이트도 생성하도록 _package.json_ 의 빌드 스크립트를 업데이트합니다. `export` 명령은 정적 사이트를 생성합니다.
 
     ```json
     "scripts": {


### PR DESCRIPTION
Added space between markdown word and others. Because for applying a markdown style(e.g. italic) must make a space.

제안하는 데 유용한 정보:
1. [빠른 시작 지역화 스타일 가이드](https://docs.microsoft.com/globalization/localization/styleguides)로 이동하여 Microsoft 스타일 가이드에서 **상위 10개의 가장 중요한 규칙**을 확인합니다.
2. [Microsoft 언어 포털](https://www.microsoft.com/language)로 이동하여 Microsoft 제품에서 **표준화된 용어 번역**을 확인합니다.
