### PR TITLE
Translate articles/aks/scale-cluster.md in Korean

### DIFF
--- a/articles/aks/scale-cluster.md
+++ b/articles/aks/scale-cluster.md
@@ -13,11 +13,11 @@ ms.locfileid: "90902937"
 ---
 # <a name="scale-the-node-count-in-an-azure-kubernetes-service-aks-cluster"></a>AKS(Azure Kubernetes Service) 클러스터의 노드 수 조정
 
-애플리케이션의 리소스 요구량이 변경되면 AKS 클러스터의 크기를 수동으로 조정하여 실행되는 노드 수를 변경할 수 있습니다. 클러스터를 축소하면 실행 중인 애플리케이션의 중단을 최소화하기 위해 노드 수가 적절하게 [제한 및 감소][kubernetes-drain]됩니다. 수직 확장 하는 경우 AKS은 노드가 Kubernetes 클러스터에 표시 될 때까지 기다린 후 `Ready` pod 예약 됩니다.
+애플리케이션의 리소스 요구량이 변경되면 AKS 클러스터의 크기를 수동으로 조정하여 실행되는 노드 수를 변경할 수 있습니다. 클러스터를 축소하면 실행 중인 애플리케이션의 중단을 최소화하기 위해 노드 수가 적절하게 [차단 및 배출][kubernetes-drain]됩니다. 확장의 경우 AKS는 pod가 예약되기 전에 Kubernetes 클러스터에 의해 노드가 `Ready`로 표시 될 때까지 기다립니다.
 
 ## <a name="scale-the-cluster-nodes"></a>클러스터 노드 크기 조정
 
-먼저 [az aks show][az-aks-show] 명령을 사용 하 여 노드 풀의 *이름을* 가져옵니다. 다음 예제에서는 *Myresourcegroup* 리소스 그룹에서 *myAKSCluster* 이라는 클러스터의 노드 풀 이름을 가져옵니다.
+먼저 [az aks show][az-aks-show] 명령을 사용 하여 노드 풀의 *이름*을 가져옵니다. 다음 예제에서는 *Myresourcegroup* 리소스 그룹에서 *myAKSCluster* 이라는 클러스터의 노드 풀 이름을 가져옵니다.
 
 ```azurecli-interactive
 az aks show --resource-group myResourceGroup --name myAKSCluster --query agentPoolProfiles
@@ -39,13 +39,13 @@ az aks show --resource-group myResourceGroup --name myAKSCluster --query agentPo
 ]
 ```
 
-[Az aks scale][az-aks-scale] 명령을 사용 하 여 클러스터 노드의 크기를 조정 합니다. 다음 예제에서는 *myAKSCluster*라는 클러스터를 단일 노드로 크기 조정합니다. `--nodepool-name` *Nodepool1*와 같은 이전 명령에서 직접 제공 합니다.
+[Az aks scale][az-aks-scale] 명령을 사용 하여 클러스터 노드의 크기를 조정 합니다. 다음 예제에서는 *myAKSCluster*라는 클러스터를 단일 노드로 크기 조정합니다. 이전 명령의 `--nodepool-name`, 즉, *Nodepool1*을 제공 합니다.
 
 ```azurecli-interactive
 az aks scale --resource-group myResourceGroup --name myAKSCluster --node-count 1 --nodepool-name <your node pool name>
 ```
 
-다음 예제 출력에는 *agentPoolProfiles* 섹션에 나와 있는 것처럼 클러스터의 크기가 노드 하나로 올바르게 조정되었음이 표시됩니다.
+다음 예제 출력에는 *agentPoolProfiles* 섹션에서 보이는 바와 같이 클러스터의 크기가 노드 하나로 올바르게 조정되었음을 보여줍니다.
 
 ```json
 {
@@ -70,20 +70,20 @@ az aks scale --resource-group myResourceGroup --name myAKSCluster --node-count 1
 
 ## <a name="scale-user-node-pools-to-0"></a>`User`노드 풀 크기를 0으로 조정
 
-`System`항상 노드를 실행 해야 하는 노드 풀과 달리 `User` 노드 풀을 사용 하면 0으로 확장할 수 있습니다. 시스템 및 사용자 노드 풀의 차이점에 대해 자세히 알아보려면 [시스템 및 사용자 노드 풀](use-system-pools.md)을 참조 하세요.
+항상 노드가 실행 중이어야 하는 `System` 노드 풀과 달리 `User` 노드 풀은 0으로 크기 조정할 수 있습니다. 시스템 및 사용자 노드 풀의 차이점에 대해 자세히 알아보려면 [시스템 및 사용자 노드 풀](use-system-pools.md)을 참조 하세요.
 
-사용자 풀의 크기를 0으로 조정 하려면 위 명령 대신 [az aks nodepool scale][az-aks-nodepool-scale] 을 사용 하 `az aks scale` 고 노드 수로 0을 설정할 수 있습니다.
+사용자 풀의 크기를 0으로 조정 하려면 위 `az aks scale` 명령 대신 [az aks nodepool scale][az-aks-nodepool-scale]을 사용 하고 노드 수로 0을 설정할 수 있습니다.
 
 
 ```azurecli-interactive
 az aks nodepool scale --name <your node pool name> --cluster-name myAKSCluster --resource-group myResourceGroup  --node-count 0 
 ```
 
-`User` `--min-count` [클러스터 Autoscaler](cluster-autoscaler.md) 의 매개 변수를 0으로 설정 하 여 노드 풀을 0 개 노드로 자동 크기 조정 할 수도 있습니다.
+[클러스터 Autoscaler](cluster-autoscaler.md) `--min-count`의 매개 변수를 0으로 설정 하여 `User` 노드 풀을 0 개 노드로 자동 크기 조정 할 수도 있습니다.
 
 ## <a name="next-steps"></a>다음 단계
 
-이 문서에서는 AKS 클러스터를 수동으로 확장 하 여 노드 수를 늘리거나 줄입니다. [클러스터 autoscaler][cluster-autoscaler] 를 사용 하 여 클러스터를 자동으로 확장할 수도 있습니다.
+이 문서에서는 노드 수를 늘리거나 줄이기 위해 AKS 클러스터를 수동으로 확장했습니다. [클러스터 autoscaler][cluster-autoscaler]를 사용하여 클러스터를 자동으로 확장 할 수도 있습니다.
 
 <!-- LINKS - external -->
 [kubernetes-drain]: https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/


### PR DESCRIPTION
[AKS(Azure Kubernetes Service) 클러스터의 노드 수 조정](https://docs.microsoft.com/ko-kr/azure/aks/scale-cluster) 페이지 내 기계번역에 의한 부자연스런 번역과 띄어쓰기를 수정하여 제출합니다. 검토 요청 드립니다.