### PR TITLE
오타 수정("Az" to "az") 및 한글화 번역 오류 정정

### DIFF
--- a/articles/aks/scale-cluster.md
+++ b/articles/aks/scale-cluster.md
@@ -39,7 +39,7 @@ az aks show --resource-group myResourceGroup --name myAKSCluster --query agentPo
 ]
 ```
 
-[Az aks scale][az-aks-scale] 명령을 사용 하여 클러스터 노드의 크기를 조정 합니다. 다음 예제에서는 *myAKSCluster* 라는 클러스터를 단일 노드로 크기 조정합니다. `--nodepool-name`, 즉,  , 즉, *, 즉, Nodepool1, 즉,*, 즉, 을 제공 합니다., 즉, 
+[az aks scale][az-aks-scale] 명령을 사용 하여 클러스터 노드의 크기를 조정 합니다. 다음 예제에서는 *myAKSCluster* 라는 클러스터를 단일 노드로 크기 조정합니다. nodepool1과 같이 이전 명령에서의 고유한 `--nodepool-name`을 입력합니다.
 
 ```azurecli-interactive
 az aks scale --resource-group myResourceGroup --name myAKSCluster --node-count 1 --nodepool-name <your node pool name>


### PR DESCRIPTION
명령어에 대한 오타 수정 ("Az aks scale" to "(az aks scale") 과 더불어 한글화 번역 오류에 대해 바로 잡아 검토 요청 드립니다.

번역 오류 : --nodepool-name, 즉, , 즉, , 즉, Nodepool1, 즉,, 즉, 을 제공 합니다., 즉,
번역 제안 : nodepool1과 같이 이전 명령에서의 고유한 `--nodepool-name`을 입력합니다.

제안하는 데 유용한 정보:
1. [빠른 시작 지역화 스타일 가이드](https://docs.microsoft.com/globalization/localization/styleguides)로 이동하여 Microsoft 스타일 가이드에서 **상위 10개의 가장 중요한 규칙**을 확인합니다.
2. [Microsoft 언어 포털](https://www.microsoft.com/language)로 이동하여 Microsoft 제품에서 **표준화된 용어 번역**을 확인합니다.
