### PR TITLE
번역 오류 정정("별색" to "스폿")

### DIFF
--- a/articles/aks/start-stop-cluster.md
+++ b/articles/aks/start-stop-cluster.md
@@ -87,7 +87,7 @@ az aks start --name myAKSCluster --resource-group myResourceGroup
 ## <a name="next-steps"></a>다음 단계
 
 - 풀 크기를 0으로 조정 하는 방법에 대한 자세한 `User` 내용은 [ `User` 풀 크기 조정](scale-cluster.md#scale-user-node-pools-to-0)을 참조 하세요.
-- 스폿 인스턴스를 사용하여 비용을 절감 하는 방법을 알아보려면 [AKS에 별색 노드 풀 추가](spot-node-pool.md)를 참조 하세요.
+- 스폿 인스턴스를 사용하여 비용을 절감 하는 방법을 알아보려면 [AKS에 스폿 노드 풀 추가](spot-node-pool.md)를 참조 하세요.
 - AKS 지원 정책에 대한 자세한 내용은 [AKS 지원 정책](support-policies.md)을 참조 하세요.
 
 <!-- LINKS - external -->


### PR DESCRIPTION
spot-node-pool에 대해 "별색 노드 풀"로 번역되어 있어 이를 "스폿 노드 풀"로 정정합니다.

제안하는 데 유용한 정보:
1. [빠른 시작 지역화 스타일 가이드](https://docs.microsoft.com/globalization/localization/styleguides)로 이동하여 Microsoft 스타일 가이드에서 **상위 10개의 가장 중요한 규칙**을 확인합니다.
2. [Microsoft 언어 포털](https://www.microsoft.com/language)로 이동하여 Microsoft 제품에서 **표준화된 용어 번역**을 확인합니다.
